### PR TITLE
Fixes incorrect run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## KorGE samples
 
 ```bash
-./gradlew :sample-box2d:runJvm
+./gradlew :samples:box2d:runJvm
 ```


### PR DESCRIPTION
I am guessing that things changes over time, but as far as I can see, the proper way to run the samples is to do `:folder:type:command`.